### PR TITLE
Fix Router import

### DIFF
--- a/my-react-app/src/main.jsx
+++ b/my-react-app/src/main.jsx
@@ -1,7 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.scss'
-import App from './App.jsx'
+import Router from './router.jsx'
 
 
 createRoot(document.getElementById('root')).render(


### PR DESCRIPTION
## Summary
- use `<Router />` in `main.jsx`

## Testing
- `npm run lint` *(fails: Cannot find package `@eslint/js`)*
- `npm run build` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685a7e942a5883319b7c9c7b85cd47ed