### PR TITLE
Add npm start script

### DIFF
--- a/my-react-app/package.json
+++ b/my-react-app/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "start": "vite",
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview"


### PR DESCRIPTION
## Summary
- add `start` script that launches the Vite dev server

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_b_685a7e954c408331af2358e9ccf55e34