### PR TITLE
Display host info, rating and tags

### DIFF
--- a/my-react-app/src/components/HostInfo.jsx
+++ b/my-react-app/src/components/HostInfo.jsx
@@ -1,0 +1,10 @@
+import './HostInfo.scss'
+
+export default function HostInfo({ name, picture }) {
+  return (
+    <div className="host-info">
+      <img src={picture} alt={name} />
+      <span>{name}</span>
+    </div>
+  )
+}

--- a/my-react-app/src/components/HostInfo.scss
+++ b/my-react-app/src/components/HostInfo.scss
@@ -1,0 +1,11 @@
+.host-info {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  img {
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    object-fit: cover;
+  }
+}

--- a/my-react-app/src/components/RatingStars.jsx
+++ b/my-react-app/src/components/RatingStars.jsx
@@ -1,0 +1,13 @@
+import './RatingStars.scss'
+
+export default function RatingStars({ rating = 0 }) {
+  const stars = []
+  for (let i = 1; i <= 5; i++) {
+    stars.push(
+      <span key={i} className={`star ${i <= rating ? 'filled' : ''}`}>
+        ★
+      </span>
+    )
+  }
+  return <div className="rating-stars">{stars}</div>
+}

--- a/my-react-app/src/components/RatingStars.scss
+++ b/my-react-app/src/components/RatingStars.scss
@@ -1,0 +1,9 @@
+.rating-stars {
+  .star {
+    color: #e3e3e3;
+    font-size: 1.2rem;
+    &.filled {
+      color: #ff6060;
+    }
+  }
+}

--- a/my-react-app/src/components/TagList.jsx
+++ b/my-react-app/src/components/TagList.jsx
@@ -1,0 +1,13 @@
+import './TagList.scss'
+
+export default function TagList({ tags = [] }) {
+  return (
+    <div className="tag-list">
+      {tags.map((tag) => (
+        <span key={tag} className="tag">
+          {tag}
+        </span>
+      ))}
+    </div>
+  )
+}

--- a/my-react-app/src/components/TagList.scss
+++ b/my-react-app/src/components/TagList.scss
@@ -1,0 +1,12 @@
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+
+  .tag {
+    background: #f1f1f1;
+    padding: 0.25rem 0.75rem;
+    border-radius: 1rem;
+    font-size: 0.9rem;
+  }
+}

--- a/my-react-app/src/pages/Property.jsx
+++ b/my-react-app/src/pages/Property.jsx
@@ -2,6 +2,9 @@ import { useParams, Navigate } from 'react-router-dom'
 import data from '../../data/data.json'
 import Slideshow from '../components/Slideshow'
 import Collapse from '../components/Collapse'
+import HostInfo from '../components/HostInfo'
+import RatingStars from '../components/RatingStars'
+import TagList from '../components/TagList'
 import './Property.scss'
 
 export default function Property() {
@@ -13,8 +16,17 @@ export default function Property() {
   return (
     <div className="property">
       <Slideshow images={item.pictures} />
-      <h1>{item.title}</h1>
-      <p>{item.location}</p>
+      <div className="header">
+        <div className="main-info">
+          <h1>{item.title}</h1>
+          <p>{item.location}</p>
+          <TagList tags={item.tags} />
+        </div>
+        <div className="side-info">
+          <HostInfo name={item.host.name} picture={item.host.picture} />
+          <RatingStars rating={parseInt(item.rating, 10)} />
+        </div>
+      </div>
       <Collapse title="Description">{item.description}</Collapse>
       <Collapse title="Équipements">
         <ul>

--- a/my-react-app/src/pages/Property.scss
+++ b/my-react-app/src/pages/Property.scss
@@ -1,7 +1,21 @@
 .property {
   max-width: 800px;
   margin: auto;
-  h1 {
+  .header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
     margin-top: 1rem;
+    flex-wrap: wrap;
+    gap: 1rem;
+  }
+  .main-info {
+    flex: 1 1 60%;
+  }
+  .side-info {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.5rem;
   }
 }


### PR DESCRIPTION
## Summary
- add HostInfo, RatingStars and TagList UI components
- show host details, rating and tags on Property page
- style the new pieces

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_685d0590e60483319ec3141522a3b00b