### PR TITLE
Fix layout overflow

### DIFF
--- a/my-react-app/src/index.scss
+++ b/my-react-app/src/index.scss
@@ -1,5 +1,11 @@
 @use './styles/variables' as *;
 
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
 :root {
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;


### PR DESCRIPTION
## Summary
- apply global box-sizing to prevent layout overflow

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_686197749a408331aff15f89888f3c6b